### PR TITLE
Feature/sc 45389

### DIFF
--- a/pkg/helm/ethereum/geth.go
+++ b/pkg/helm/ethereum/geth.go
@@ -75,8 +75,7 @@ func (m Chart) ExportData(e *environment.Environment) error {
 		log.Info().Str("Name", "Geth").Str("URLs", gethLocalWs).Msg("Geth network")
 
 	} else {
-		e.URLs[m.Props.NetworkName] = m.Props.WsURLs
-		e.URLs[m.Props.NetworkName] = m.Props.HttpURLs
+		e.URLs[m.Props.NetworkName] = append(m.Props.WsURLs, m.Props.HttpURLs...)
 		log.Info().Str("Name", m.Props.NetworkName).Strs("URLs", m.Props.WsURLs).Msg("Ethereum network")
 	}
 	return nil

--- a/pkg/helm/ethereum/geth.go
+++ b/pkg/helm/ethereum/geth.go
@@ -49,21 +49,34 @@ func (m Chart) GetValues() *map[string]interface{} {
 
 func (m Chart) ExportData(e *environment.Environment) error {
 	if m.Props.Simulated {
-		gethLocal, err := e.Fwd.FindPort("geth:0", "geth-network", "ws-rpc").As(client.LocalConnection, client.WS)
+		gethLocalHttp, err := e.Fwd.FindPort("geth:0", "geth-network", "http-rpc").As(client.LocalConnection, client.HTTP)
 		if err != nil {
 			return err
 		}
-		gethInternal, err := e.Fwd.FindPort("geth:0", "geth-network", "ws-rpc").As(client.RemoteConnection, client.WS)
+		gethInternalHttp, err := e.Fwd.FindPort("geth:0", "geth-network", "http-rpc").As(client.RemoteConnection, client.HTTP)
 		if err != nil {
 			return err
 		}
-		e.URLs[m.Props.NetworkName] = []string{gethLocal}
+		gethLocalWs, err := e.Fwd.FindPort("geth:0", "geth-network", "ws-rpc").As(client.LocalConnection, client.WS)
+		if err != nil {
+			return err
+		}
+		gethInternalWs, err := e.Fwd.FindPort("geth:0", "geth-network", "ws-rpc").As(client.RemoteConnection, client.WS)
+		if err != nil {
+			return err
+		}
+		e.URLs[m.Props.NetworkName] = append(e.URLs[m.Props.NetworkName], gethLocalWs)
+		e.URLs[m.Props.NetworkName] = append(e.URLs[m.Props.NetworkName], gethLocalHttp)
+
 		if e.Cfg.InsideK8s {
-			e.URLs[m.Props.NetworkName] = []string{gethInternal}
+			e.URLs[m.Props.NetworkName] = append(e.URLs[m.Props.NetworkName], gethInternalWs)
+			e.URLs[m.Props.NetworkName] = append(e.URLs[m.Props.NetworkName], gethInternalHttp)
 		}
-		log.Info().Str("Name", "Geth").Str("URLs", gethLocal).Msg("Geth network")
+		log.Info().Str("Name", "Geth").Str("URLs", gethLocalWs).Msg("Geth network")
+
 	} else {
 		e.URLs[m.Props.NetworkName] = m.Props.WsURLs
+		e.URLs[m.Props.NetworkName] = m.Props.HttpURLs
 		log.Info().Str("Name", m.Props.NetworkName).Strs("URLs", m.Props.WsURLs).Msg("Ethereum network")
 	}
 	return nil

--- a/pkg/helm/ethereum/geth.go
+++ b/pkg/helm/ethereum/geth.go
@@ -68,10 +68,10 @@ func (m Chart) ExportData(e *environment.Environment) error {
 		e.URLs[m.Props.NetworkName] = append(e.URLs[m.Props.NetworkName], gethLocalWs)
 		e.URLs[m.Props.NetworkName] = append(e.URLs[m.Props.NetworkName], gethLocalHttp)
 
-		if e.Cfg.InsideK8s {
-			e.URLs[m.Props.NetworkName] = append(e.URLs[m.Props.NetworkName], gethInternalWs)
-			e.URLs[m.Props.NetworkName] = append(e.URLs[m.Props.NetworkName], gethInternalHttp)
-		}
+		// For cases like starknet we need the internalHttp address to set up the L1<>L2 interaction
+		e.URLs[m.Props.NetworkName] = append(e.URLs[m.Props.NetworkName], gethInternalWs)
+		e.URLs[m.Props.NetworkName] = append(e.URLs[m.Props.NetworkName], gethInternalHttp)
+
 		log.Info().Str("Name", "Geth").Str("URLs", gethLocalWs).Msg("Geth network")
 
 	} else {

--- a/pkg/helm/starknet/starknet.go
+++ b/pkg/helm/starknet/starknet.go
@@ -54,12 +54,8 @@ func (m Chart) ExportData(e *environment.Environment) error {
 		return err
 	}
 	e.URLs[m.Props.NetworkName] = append(e.URLs[m.Props.NetworkName], devnetLocalHttp)
-
-	if e.Cfg.InsideK8s {
-		e.URLs[m.Props.NetworkName] = append(e.URLs[m.Props.NetworkName], devnetInternalHttp)
-	}
+	e.URLs[m.Props.NetworkName] = append(e.URLs[m.Props.NetworkName], devnetInternalHttp)
 	log.Info().Str("Name", "Devnet").Str("URLs", devnetLocalHttp).Msg("Devnet network")
-
 	return nil
 }
 

--- a/pkg/helm/starknet/starknet.go
+++ b/pkg/helm/starknet/starknet.go
@@ -49,11 +49,11 @@ func (m Chart) GetValues() *map[string]interface{} {
 }
 
 func (m Chart) ExportData(e *environment.Environment) error {
-	devnetLocalHttp, err := e.Fwd.FindPort("starknet-dev:0", "starknet-dev").As(client.LocalConnection, client.HTTP)
+	devnetLocalHttp, err := e.Fwd.FindPort("starknet-dev:0", "starknet-dev", "http").As(client.LocalConnection, client.HTTP)
 	if err != nil {
 		return err
 	}
-	devnetInternalHttp, err := e.Fwd.FindPort("starknet-dev:0,", "starknet-dev").As(client.RemoteConnection, client.HTTP)
+	devnetInternalHttp, err := e.Fwd.FindPort("starknet-dev:0,", "starknet-dev", "http").As(client.RemoteConnection, client.HTTP)
 	if err != nil {
 		return err
 	}

--- a/pkg/helm/starknet/starknet.go
+++ b/pkg/helm/starknet/starknet.go
@@ -6,10 +6,6 @@ import (
 	"github.com/smartcontractkit/chainlink-env/environment"
 )
 
-const (
-	URLsKey = "starknet-dev"
-)
-
 type Props struct {
 	NetworkName string   `envconfig:"network_name"`
 	HttpURLs    []string `envconfig:"http_url"`

--- a/pkg/helm/starknet/starknet.go
+++ b/pkg/helm/starknet/starknet.go
@@ -50,11 +50,11 @@ func (m Chart) GetValues() *map[string]interface{} {
 
 func (m Chart) ExportData(e *environment.Environment) error {
 	urls := make([]string, 0)
-	devnet, err := e.Fwd.FindPort("mockserver:0", "mockserver", "serviceport").As(client.LocalConnection, client.HTTP)
+	devnet, err := e.Fwd.FindPort("devnet:0", "devnet", "serviceport").As(client.LocalConnection, client.HTTP)
 	if err != nil {
 		return err
 	}
-	devnetInternal, err := e.Fwd.FindPort("mockserver:0", "mockserver", "serviceport").As(client.RemoteConnection, client.HTTP)
+	devnetInternal, err := e.Fwd.FindPort("devnet:0", "devnet", "serviceport").As(client.RemoteConnection, client.HTTP)
 	if err != nil {
 		return err
 	}

--- a/pkg/helm/starknet/starknet.go
+++ b/pkg/helm/starknet/starknet.go
@@ -103,7 +103,7 @@ func New(props *Props) environment.ConnectedChart {
 	return Chart{
 		HelmProps: &HelmProps{
 			Name:   "devnet",
-			Path:   "../../../qa-charts/charts/starknet",
+			Path:   "chainlink-qa/starknet",
 			Values: &props.Values,
 		},
 		Props: props,

--- a/pkg/helm/starknet/starknet.go
+++ b/pkg/helm/starknet/starknet.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	URLsKey = "devnet"
+	URLsKey = "starknet-dev"
 )
 
 type Props struct {
@@ -49,11 +49,11 @@ func (m Chart) GetValues() *map[string]interface{} {
 }
 
 func (m Chart) ExportData(e *environment.Environment) error {
-	devnetLocalHttp, err := e.Fwd.FindPort("starknet-dev:0", "starknet-dev", "http").As(client.LocalConnection, client.HTTP)
+	devnetLocalHttp, err := e.Fwd.FindPort("starknet-dev:0", "starknetdev", "http").As(client.LocalConnection, client.HTTP)
 	if err != nil {
 		return err
 	}
-	devnetInternalHttp, err := e.Fwd.FindPort("starknet-dev:0,", "starknet-dev", "http").As(client.RemoteConnection, client.HTTP)
+	devnetInternalHttp, err := e.Fwd.FindPort("starknet-dev:0", "starknetdev", "http").As(client.RemoteConnection, client.HTTP)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func New(props *Props) environment.ConnectedChart {
 	return Chart{
 		HelmProps: &HelmProps{
 			Name:   "starknet-dev",
-			Path:   "../../../qa-charts/charts/starknet",
+			Path:   "chainlink-qa/starknet",
 			Values: &props.Values,
 		},
 		Props: props,


### PR DESCRIPTION
- Edited the geth node to also return http-rpc Url's, previously only ws-rpc was returned, probably missed during refactor
- Edited the geth node to return remote RPC Url's, previously it was only returned for soak tests, reason for this is that starknet requires the remote Url of the geth pod
- Added configuration for starknet devnet client