### PR TITLE
Adds support for K8S_NODE_SELECTOR and K8S_TOLERATIONS env vars

### DIFF
--- a/config/overrides.go
+++ b/config/overrides.go
@@ -47,6 +47,14 @@ const (
 	EnvVarSlackUser            = "SLACK_USER"
 	EnvVarSlackUserDescription = "The Slack code for the user you want to notify"
 	EnvVarSlackUserExample     = "U000000000"
+
+	EnvVarToleration                 = "K8S_TOLERATION"
+	EnvVarTolerationsUserDescription = "Node roles to tolerate"
+	EnvVarTolerationsExample         = "foundations"
+
+	EnvVarNodeSelector                = "K8S_NODE_SELECTOR"
+	EnvVarNodeSelectorUserDescription = "Node role to deploy to"
+	EnvVarNodeSelectorExample         = "foundations"
 )
 
 func MustMerge(targetVars interface{}, codeVars interface{}) {


### PR DESCRIPTION
This will allow foundations to automatically have everything deployed to their nodes instead of QA, rather than requiring modification of specific tests or higher level api's.