### PR TITLE
clean up unused variables in remote test runner

### DIFF
--- a/pkg/helm/remotetestrunner/runner.go
+++ b/pkg/helm/remotetestrunner/runner.go
@@ -58,21 +58,19 @@ func defaultProps() map[string]interface{} {
 	log.Info().Str("API Key", slackKey).Str("Channel", slackChannel).Str("User", slackUser).Msg("Using Slack Creds")
 	return map[string]interface{}{
 		"remote_test_runner": map[string]interface{}{
-			"test_name":        "@soak-ocr",
-			"slack_api":        slackKey,
-			"slack_channel":    slackChannel,
-			"slack_user_id":    slackUser,
-			"remote_test_size": 0,
-			"access_port":      8080,
+			"slack_api":     slackKey,
+			"slack_channel": slackChannel,
+			"slack_user_id": slackUser,
+			"access_port":   8080,
 		},
 		"resources": map[string]interface{}{
 			"requests": map[string]interface{}{
-				"cpu":    "250m",
-				"memory": "512Mi",
+				"cpu":    "2000m",
+				"memory": "1536Mi",
 			},
 			"limits": map[string]interface{}{
-				"cpu":    "250m",
-				"memory": "512Mi",
+				"cpu":    "2000m",
+				"memory": "1536Mi",
 			},
 		},
 	}
@@ -84,6 +82,17 @@ func New(props map[string]interface{}) environment.ConnectedChart {
 	return Chart{
 		Name:   "remote-test-runner",
 		Path:   "chainlink-qa/remote-test-runner",
+		Values: &dp,
+	}
+}
+
+// NewLocal Use a local chart path instead of a remote one, very useful for debugging chart changes
+func NewLocal(props map[string]interface{}, chartPath string) environment.ConnectedChart {
+	dp := defaultProps()
+	config.MustMerge(&dp, props)
+	return Chart{
+		Name:   "remote-test-runner",
+		Path:   chartPath,
 		Values: &dp,
 	}
 }


### PR DESCRIPTION
Do not merge until https://github.com/smartcontractkit/qa-charts/pull/22 is merged and tested