### PR TITLE
Add chaos label by app name

### DIFF
--- a/client/chaos.go
+++ b/client/chaos.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
 	"github.com/rs/zerolog/log"
 )

--- a/client/client.go
+++ b/client/client.go
@@ -109,6 +109,22 @@ func (m *K8sClient) LabelChaosGroup(namespace string, startInstance int, endInst
 	return nil
 }
 
+func (m *K8sClient) LabelChaosGroupByApp(namespace string, app string, startInstance int, endInstance int, group string) error {
+	for i := startInstance; i <= endInstance; i++ {
+		podList, err := m.ListPods(namespace, fmt.Sprintf("app=%s, instance=%d", app, i))
+		if err != nil {
+			return err
+		}
+		for _, pod := range podList.Items {
+			err = m.AddLabelByPod(namespace, pod, group, "1")
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // UniqueLabels gets all unique application labels
 func (m *K8sClient) UniqueLabels(namespace string, selector string) ([]string, error) {
 	uniqueLabels := make([]string, 0)


### PR DESCRIPTION
In existing implementation of `LabelChaosGroup` if multiple apps had same instances the chaos label was getting added to those all. Added a method to filter the pods by both app name and instance to add the label.