### PR TITLE
system tests coverage per service/module

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ If you have [chaosmesh]() installed in your cluster you can pull and generated C
 ```
 make chaosmesh
 ```
+
+If you need to check your system tests coverage, use [that](TUTORIAL.md#coverage)

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -17,6 +17,7 @@
   - [Collecting logs](#collecting-logs)
   - [Resources summary](#resources-summary)
 - [Chaos](#chaos)
+- [Coverage](#coverage)
 
 
 ## Getting started
@@ -504,3 +505,49 @@ func main() {
 
 # Chaos
 Check our [tests](https://github.com/smartcontractkit/chainlink/blob/develop/integration-tests/chaos/chaos_test.go) to see how we using Chaosmesh
+
+# Coverage
+Build your target image with those 2 steps to allow automatic coverage discovery
+```Dockerfile
+FROM ...
+
+# add those 2 steps to instrument the code
+RUN curl -s https://api.github.com/repos/qiniu/goc/releases/latest | grep "browser_download_url.*-linux-amd64.tar.gz" | cut -d : -f 2,3 | tr -d \" | xargs -n 1 curl -L | tar -zx && chmod +x goc && mv goc /usr/local/bin
+# -o my_service means service will be called "my_service" in goc coverage service
+# --center http://goc:7777 means that on deploy, your instrumented service will automatically register to a local goc node inside your deployment (namespace)
+RUN goc build -o my_service . --center http://goc:7777
+
+CMD ["./my_service"]
+```
+Add `goc` to your deployment, check example with `dummy` service deployment:
+```golang
+package main
+
+import (
+  "time"
+
+  "github.com/smartcontractkit/chainlink-env/environment"
+  goc "github.com/smartcontractkit/chainlink-env/pkg/cdk8s/goc"
+  dummy "github.com/smartcontractkit/chainlink-env/pkg/cdk8s/http_dummy"
+)
+
+func main() {
+  e := environment.New(nil).
+    AddChart(goc.New()).
+    AddChart(dummy.New())
+  if err := e.Run(); err != nil {
+    panic(err)
+  }
+  // run your test logic here
+  time.Sleep(1 * time.Minute)
+  if err := e.SaveCoverage(); err != nil {
+    panic(err)
+  }
+  // clear the coverage, rerun the tests again if needed
+  if err := e.ClearCoverage(); err != nil {
+    panic(err)
+  }
+}
+
+```
+After tests are finished, coverage is collected for every service, check `cover` directory

--- a/client/client.go
+++ b/client/client.go
@@ -24,7 +24,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -158,32 +157,6 @@ func (m *K8sClient) UniqueLabels(namespace string, selector string) ([]string, e
 		Interface("Apps", uniqueLabels).
 		Msg("Apps found")
 	return uniqueLabels, nil
-}
-
-// Poll up to timeout seconds for pod to enter running state.
-// Returns an error if the pod never enters the running state.
-func waitForPodRunning(c kubernetes.Interface, namespace, podName string, timeout time.Duration) error {
-	return wait.PollImmediate(2*time.Second, timeout, isPodRunning(c, podName, namespace))
-}
-
-// return a condition function that indicates whether the given pod is
-// currently running
-func isPodRunning(c kubernetes.Interface, podName, namespace string) wait.ConditionFunc {
-	return func() (bool, error) {
-		pod, err := c.CoreV1().Pods(namespace).Get(context.Background(), podName, metaV1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		switch pod.Status.Phase {
-		case v1.PodRunning:
-			fallthrough
-		case v1.PodSucceeded:
-			return true, nil
-		case v1.PodFailed:
-			return false, errors.New("pod failed")
-		}
-		return false, nil
-	}
 }
 
 // AddLabelByPod adds a label to a pod

--- a/e2e/envs_test.go
+++ b/e2e/envs_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/smartcontractkit/chainlink-env/environment"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/chainlink"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/ethereum"
-	"github.com/smartcontractkit/chainlink-env/pkg/helm/remotetestrunner"
 	"github.com/smartcontractkit/chainlink-env/presets"
 	"github.com/stretchr/testify/require"
 )
@@ -90,32 +89,6 @@ func TestSimpleEnv(t *testing.T) {
 			AddHelm(ethereum.New(nil)).
 			AddHelm(chainlink.New(0, nil)).
 			AddHelm(chainlink.New(1, nil))
-		err := e.Run()
-		// nolint
-		defer e.Shutdown()
-		require.NoError(t, err)
-	})
-	t.Run("test remote runner", func(t *testing.T) {
-		e := environment.New(testEnvConfig).
-			AddHelm(ethereum.New(nil)).
-			AddHelm(chainlink.New(0, nil)).
-			AddHelm(remotetestrunner.New(map[string]interface{}{
-				"remote_test_runner": map[string]interface{}{
-					"test_name":        "@soak-ocr",
-					"remote_test_size": 0,
-					"access_port":      8080,
-				},
-				"resources": map[string]interface{}{
-					"requests": map[string]interface{}{
-						"cpu":    "500m",
-						"memory": "512Mi",
-					},
-					"limits": map[string]interface{}{
-						"cpu":    "500m",
-						"memory": "512Mi",
-					},
-				},
-			}))
 		err := e.Run()
 		// nolint
 		defer e.Shutdown()

--- a/environment/artifacts.go
+++ b/environment/artifacts.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/smartcontractkit/chainlink-env/client"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/smartcontractkit/chainlink-env/client"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -39,7 +40,7 @@ func NewArtifacts(client *client.K8sClient, namespace string) (*Artifacts, error
 // DumpTestResult dumps all pods logs and db dump in a separate test dir
 func (a *Artifacts) DumpTestResult(testDir string, dbName string) error {
 	a.DBName = dbName
-	if err := mkdirIfNotExists(testDir); err != nil {
+	if err := MkdirIfNotExists(testDir); err != nil {
 		return err
 	}
 	if err := a.writePodArtifacts(testDir); err != nil {
@@ -66,7 +67,7 @@ func (a *Artifacts) writePodArtifacts(testDir string) error {
 		appName := pod.Labels["app"]
 		instance := pod.Labels["instance"]
 		appDir := filepath.Join(testDir, fmt.Sprintf("%s_%s", appName, instance))
-		if err := mkdirIfNotExists(appDir); err != nil {
+		if err := MkdirIfNotExists(appDir); err != nil {
 			return err
 		}
 		err = a.writePodLogs(pod, appDir)
@@ -176,7 +177,7 @@ func (a *Artifacts) writePodLogs(pod coreV1.Pod, appDir string) error {
 	return nil
 }
 
-func mkdirIfNotExists(dirName string) error {
+func MkdirIfNotExists(dirName string) error {
 	if _, err := os.Stat(dirName); os.IsNotExist(err) {
 		if err = os.MkdirAll(dirName, os.ModePerm); err != nil {
 			return errors.Wrapf(err, "failed to create directory: %s", dirName)

--- a/examples/coverage/Dockerfile
+++ b/examples/coverage/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.19-buster
+
+RUN curl -s https://api.github.com/repos/qiniu/goc/releases/latest | grep "browser_download_url.*-linux-amd64.tar.gz" | cut -d : -f 2,3 | tr -d \" | xargs -n 1 curl -L | tar -zx && chmod +x goc && mv goc /usr/local/bin
+
+CMD ["goc", "server"]

--- a/examples/coverage/Dockerfile.target
+++ b/examples/coverage/Dockerfile.target
@@ -1,0 +1,8 @@
+FROM public.ecr.aws/chainlink/goc:latest
+
+COPY . app/
+WORKDIR app/cmd
+RUN goc build -o service1 . --center http://goc:7777
+RUN chmod +x ../entrypoint.sh
+
+CMD ["../entrypoint.sh"]

--- a/examples/coverage/entrypoint.sh
+++ b/examples/coverage/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sleep 30 && ./service1

--- a/examples/coverage/env.go
+++ b/examples/coverage/env.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"time"
+
+	"github.com/smartcontractkit/chainlink-env/environment"
+	goc "github.com/smartcontractkit/chainlink-env/pkg/cdk8s/goc"
+	dummy "github.com/smartcontractkit/chainlink-env/pkg/cdk8s/http_dummy"
+)
+
+func main() {
+	e := environment.New(nil).
+		AddChart(goc.New()).
+		AddChart(dummy.New())
+	if err := e.Run(); err != nil {
+		panic(err)
+	}
+	// run your test logic here
+	time.Sleep(1 * time.Minute)
+	if err := e.SaveCoverage(); err != nil {
+		panic(err)
+	}
+	// clear the coverage, rerun the tests again if needed
+	if err := e.ClearCoverage(); err != nil {
+		panic(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
+	github.com/go-resty/resty/v2 v2.7.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/go-openapi/jsonreference v0.20.0/go.mod h1:Ag74Ico3lPc+zR+qjn4XBUmXym
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
+github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
+github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -445,6 +447,7 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b h1:ZmngSVLe/wycRns9MKikG9OWIEjGcGAkacif7oYQaUY=
 golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/pkg/cdk8s/goc/goc.go
+++ b/pkg/cdk8s/goc/goc.go
@@ -1,0 +1,141 @@
+package goc
+
+import (
+	"fmt"
+
+	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
+	"github.com/smartcontractkit/chainlink-env/environment"
+	"github.com/smartcontractkit/chainlink-env/imports/k8s"
+	a "github.com/smartcontractkit/chainlink-env/pkg/alias"
+)
+
+type Chart struct {
+	Props *Props
+}
+
+func (m *Chart) IsDeploymentNeeded() bool {
+	return true
+}
+
+func (m Chart) GetName() string {
+	return "dummy"
+}
+
+func (m Chart) GetProps() interface{} {
+	return m.Props
+}
+
+func (m Chart) GetPath() string {
+	return ""
+}
+
+func (m Chart) GetVersion() string {
+	return ""
+}
+
+func (m Chart) GetValues() *map[string]interface{} {
+	return nil
+}
+
+func (m Chart) ExportData(e *environment.Environment) error {
+	return nil
+}
+
+func New() func(root cdk8s.Chart) environment.ConnectedChart {
+	return func(root cdk8s.Chart) environment.ConnectedChart {
+		c := &Chart{}
+		vars := vars{
+			Labels: &map[string]*string{
+				"app": a.Str(c.GetName()),
+			},
+			ConfigMapName: fmt.Sprintf("%s-cm", c.GetName()),
+			BaseName:      c.GetName(),
+			Port:          3000,
+		}
+		service(root, vars)
+		deployment(root, vars)
+		return c
+	}
+}
+
+type Props struct {
+	Name string
+}
+
+// vars some shared labels/selectors and names that must match in resources
+type vars struct {
+	Labels        *map[string]*string
+	BaseName      string
+	ConfigMapName string
+	Port          float64
+	Props         *Props
+}
+
+func service(chart cdk8s.Chart, vars vars) {
+	k8s.NewKubeService(chart, a.Str(fmt.Sprintf("%s-service", vars.BaseName)), &k8s.KubeServiceProps{
+		Metadata: &k8s.ObjectMeta{
+			Name: a.Str(vars.BaseName),
+		},
+		Spec: &k8s.ServiceSpec{
+			Ports: &[]*k8s.ServicePort{
+				{
+					Name:       a.Str("http"),
+					Port:       a.Num(vars.Port),
+					TargetPort: k8s.IntOrString_FromNumber(a.Num(3000)),
+				},
+			},
+			Selector: vars.Labels,
+		},
+	})
+}
+
+func deployment(chart cdk8s.Chart, vars vars) {
+	k8s.NewKubeDeployment(
+		chart,
+		a.Str(fmt.Sprintf("%s-deployment", vars.BaseName)),
+		&k8s.KubeDeploymentProps{
+			Metadata: &k8s.ObjectMeta{
+				Name: a.Str(vars.BaseName),
+			},
+			Spec: &k8s.DeploymentSpec{
+				Selector: &k8s.LabelSelector{
+					MatchLabels: vars.Labels,
+				},
+				Template: &k8s.PodTemplateSpec{
+					Metadata: &k8s.ObjectMeta{
+						Labels: vars.Labels,
+					},
+					Spec: &k8s.PodSpec{
+						ServiceAccountName: a.Str("default"),
+						Containers: &[]*k8s.Container{
+							container(vars),
+						},
+					},
+				},
+			},
+		})
+}
+
+func container(vars vars) *k8s.Container {
+	return &k8s.Container{
+		Name:            a.Str(vars.BaseName),
+		Image:           a.Str("public.ecr.aws/chainlink/goc-target:latest"),
+		ImagePullPolicy: a.Str("Always"),
+		Ports: &[]*k8s.ContainerPort{
+			{
+				Name:          a.Str("http"),
+				ContainerPort: a.Num(vars.Port),
+			},
+		},
+		ReadinessProbe: &k8s.Probe{
+			HttpGet: &k8s.HttpGetAction{
+				Port: k8s.IntOrString_FromNumber(a.Num(vars.Port)),
+				Path: a.Str("/"),
+			},
+			InitialDelaySeconds: a.Num(20),
+			PeriodSeconds:       a.Num(5),
+		},
+		Env:       &[]*k8s.EnvVar{},
+		Resources: a.ContainerResources("100m", "512Mi", "100m", "512Mi"),
+	}
+}

--- a/pkg/cdk8s/http_dummy/dummy.go
+++ b/pkg/cdk8s/http_dummy/dummy.go
@@ -1,0 +1,157 @@
+package dummy
+
+import (
+	"fmt"
+
+	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
+	"github.com/rs/zerolog/log"
+
+	"github.com/smartcontractkit/chainlink-env/client"
+	"github.com/smartcontractkit/chainlink-env/environment"
+	"github.com/smartcontractkit/chainlink-env/imports/k8s"
+	a "github.com/smartcontractkit/chainlink-env/pkg/alias"
+)
+
+const (
+	URLsKey = "goc"
+)
+
+type Chart struct {
+	Props *Props
+}
+
+func (m *Chart) IsDeploymentNeeded() bool {
+	return true
+}
+
+func (m Chart) GetName() string {
+	return "goc"
+}
+
+func (m Chart) GetProps() interface{} {
+	return m.Props
+}
+
+func (m Chart) GetPath() string {
+	return ""
+}
+
+func (m Chart) GetVersion() string {
+	return ""
+}
+
+func (m Chart) GetValues() *map[string]interface{} {
+	return nil
+}
+
+func (m Chart) ExportData(e *environment.Environment) error {
+	url, err := e.Fwd.FindPort(
+		fmt.Sprintf("%s:0", m.GetName()),
+		m.GetName(), "http").
+		As(client.LocalConnection, client.HTTP)
+	if err != nil {
+		return err
+	}
+	log.Info().Str("URL", url).Msg("goc coverage service")
+	e.URLs[URLsKey] = []string{url}
+	return nil
+}
+
+func New() func(root cdk8s.Chart) environment.ConnectedChart {
+	return func(root cdk8s.Chart) environment.ConnectedChart {
+		c := &Chart{}
+		vars := vars{
+			Labels: &map[string]*string{
+				"app": a.Str(c.GetName()),
+			},
+			ConfigMapName: fmt.Sprintf("%s-cm", c.GetName()),
+			BaseName:      c.GetName(),
+			Port:          7777,
+		}
+		service(root, vars)
+		deployment(root, vars)
+		return c
+	}
+}
+
+type Props struct {
+	Name string
+}
+
+// vars some shared labels/selectors and names that must match in resources
+type vars struct {
+	Labels        *map[string]*string
+	BaseName      string
+	ConfigMapName string
+	Port          float64
+	Props         *Props
+}
+
+func service(chart cdk8s.Chart, vars vars) {
+	k8s.NewKubeService(chart, a.Str(fmt.Sprintf("%s-service", vars.BaseName)), &k8s.KubeServiceProps{
+		Metadata: &k8s.ObjectMeta{
+			Name: a.Str(vars.BaseName),
+		},
+		Spec: &k8s.ServiceSpec{
+			Ports: &[]*k8s.ServicePort{
+				{
+					Name:       a.Str("http"),
+					Port:       a.Num(vars.Port),
+					TargetPort: k8s.IntOrString_FromNumber(a.Num(7777)),
+				},
+			},
+			Selector: vars.Labels,
+		},
+	})
+}
+
+func deployment(chart cdk8s.Chart, vars vars) {
+	k8s.NewKubeDeployment(
+		chart,
+		a.Str(fmt.Sprintf("%s-deployment", vars.BaseName)),
+		&k8s.KubeDeploymentProps{
+			Metadata: &k8s.ObjectMeta{
+				Name: a.Str(vars.BaseName),
+			},
+			Spec: &k8s.DeploymentSpec{
+				Selector: &k8s.LabelSelector{
+					MatchLabels: vars.Labels,
+				},
+				Template: &k8s.PodTemplateSpec{
+					Metadata: &k8s.ObjectMeta{
+						Labels: vars.Labels,
+					},
+					Spec: &k8s.PodSpec{
+						ServiceAccountName: a.Str("default"),
+						Containers: &[]*k8s.Container{
+							container(vars),
+						},
+					},
+				},
+			},
+		})
+}
+
+func container(vars vars) *k8s.Container {
+	return &k8s.Container{
+		Name:            a.Str(vars.BaseName),
+		Image:           a.Str("public.ecr.aws/chainlink/goc:latest"),
+		ImagePullPolicy: a.Str("Always"),
+		Ports: &[]*k8s.ContainerPort{
+			{
+				Name:          a.Str("http"),
+				ContainerPort: a.Num(vars.Port),
+			},
+		},
+		ReadinessProbe: &k8s.Probe{
+			HttpGet: &k8s.HttpGetAction{
+				Port: k8s.IntOrString_FromNumber(a.Num(vars.Port)),
+				Path: a.Str("/v1/cover/list"),
+			},
+			InitialDelaySeconds: a.Num(20),
+			PeriodSeconds:       a.Num(5),
+		},
+		Env:       &[]*k8s.EnvVar{},
+		Resources: a.ContainerResources("200m", "512Mi", "200m", "512Mi"),
+	}
+}


### PR DESCRIPTION
Allows us to automatically collect/reset coverage of system-level tests per service/module.
Can be used as a helpful debug tool to find some non-covered places.
Check `TUTORIAL.md` updates.