### PR TITLE
Add DATABASE_URL as env variable

### DIFF
--- a/config/overrides.go
+++ b/config/overrides.go
@@ -51,6 +51,10 @@ const (
 	EnvVarSelectedNetworksDescription = "Networks to select for testing"
 	EnvVarSelectedNetworksExample     = "SIMULATED"
 
+	EnvVarDBURL            = "DATABASE_URL"
+	EnvVarDBURLDescription = "DATABASE_URL needed for component test. This is only necessary if testhelper methods are imported from core"
+	EnvVarDBURLExample     = "postgresql://postgres:node@localhost:5432/chainlink_test?sslmode=disable"
+
 	EnvVarSlackKey            = "SLACK_API_KEY"
 	EnvVarSlackKeyDescription = "The OAuth Slack API key to report tests results with"
 	EnvVarSlackKeyExample     = "xoxb-example-key"

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -10,18 +10,19 @@ import (
 	"testing"
 	"time"
 
-	cdk8s "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
+	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
 	"github.com/go-resty/resty/v2"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/chainlink-env/client"
 	"github.com/smartcontractkit/chainlink-env/config"
 	"github.com/smartcontractkit/chainlink-env/imports/k8s"
 	"github.com/smartcontractkit/chainlink-env/logging"
 	"github.com/smartcontractkit/chainlink-env/pkg"
 	a "github.com/smartcontractkit/chainlink-env/pkg/alias"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -613,6 +614,7 @@ func getEnvVarsMap(prefix string, testName string) map[string]string {
 		config.EnvVarUser,
 		config.EnvVarNodeSelector,
 		config.EnvVarSelectedNetworks,
+		config.EnvVarDBURL,
 	}
 	for _, k := range lookups {
 		v, success := os.LookupEnv(k)


### PR DESCRIPTION
ccip tests use test helper methods from core. As a result it triggers a bunch of init methods which need DATABASE_URL to be set. The DB does not need to be present it just checks whether the env variable is set.