### PR TITLE
Race Condition Fix for not always finding ports for apps

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -48,7 +48,7 @@ jobs:
         with:
           cl_repo: ${{ env.CHAINLINK_IMAGE }}
           cl_image_tag: ${{ env.CHAINLINK_VERSION }}
-          test_command_to_run: make test_e2e args="-test.parallel=5 -json" 2>&1 | tee /tmp/gotest.log | gotestfmt
+          test_command_to_run: make test_e2e_ci
           test_download_vendor_packages_command: go mod download
           artifacts_location: ./e2e/logs
           publish_check_name: E2E Test Results
@@ -58,6 +58,12 @@ jobs:
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
+      - name: Upload test log
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: test-log
+          path: /tmp/gotest.log
       - name: cleanup
         if: always()
         uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/cleanup@e72f0a768ac934afce498a802de893d89b12802f # v2.1.1

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ test:
 test_e2e:
 	go test ./e2e -count 1 -v $(args)
 
+test_e2e_ci:
+	go test ./e2e -count 1 -v -test.parallel=5 -json 2>&1 | tee /tmp/gotest.log | gotestfmt
+
 .PHONY: examples
 examples:
 	go run cmd/test.go

--- a/client/client.go
+++ b/client/client.go
@@ -157,6 +157,7 @@ func (m *K8sClient) UniqueLabels(namespace string, selector string) ([]string, e
 	}
 	log.Info().
 		Interface("Apps", uniqueLabels).
+		Int("Count", len(uniqueLabels)).
 		Msg("Apps found")
 	return uniqueLabels, nil
 }
@@ -186,8 +187,37 @@ func (m *K8sClient) EnumerateInstances(namespace string, selector string) error 
 	return nil
 }
 
+// waitForPodsExist waits for all the expected number of pods to exist
+func (m *K8sClient) waitForPodsExist(ns string, expectedPodCount int) error {
+	log.Debug().Int("ExpectedCount", expectedPodCount).Msg("Waiting for pods to exist")
+	var exitErr error
+	if err := wait.PollImmediate(2*time.Second, 10*time.Minute, func() (bool, error) {
+		apps, err2 := m.UniqueLabels(ns, "app")
+		if err2 != nil {
+			exitErr = err2
+			return false, nil
+		}
+		if len(apps) == expectedPodCount {
+			exitErr = nil
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		return err
+	}
+
+	return exitErr
+}
+
 // WaitPodsReady waits until all pods are ready
-func (m *K8sClient) WaitPodsReady(ns string, rcd *ReadyCheckData) error {
+func (m *K8sClient) WaitPodsReady(ns string, rcd *ReadyCheckData, expectedPodCount int) error {
+	// Wait for pods to exist
+	err := m.waitForPodsExist(ns, expectedPodCount)
+	if err != nil {
+		return err
+	}
+
+	// Wait for pods to be ready
 	timeout := time.NewTimer(rcd.Timeout)
 	defer timeout.Stop()
 	for {
@@ -252,32 +282,6 @@ func (m *K8sClient) RemoveNamespace(namespace string) error {
 type ReadyCheckData struct {
 	ReadinessProbeCheckSelector string
 	Timeout                     time.Duration
-}
-
-// CheckReady application heath check using ManifestOutputData params
-func (m *K8sClient) CheckReady(namespace string, c *ReadyCheckData, appCount int) error {
-	// wait for the number of enumerated apps to be at least 1 before checking
-	// for ready or we can error out on slow runs or large jobs
-	var exitErr error
-	if err := wait.PollImmediate(2*time.Second, 10*time.Minute, func() (bool, error) {
-		apps, err2 := m.UniqueLabels(namespace, "app")
-		if err2 != nil {
-			exitErr = err2
-			return false, nil
-		}
-		log.Debug().Interface("Apps", apps).Int("Count", len(apps)).Int("Expected", appCount).Msg("Found apps")
-		if len(apps) == appCount {
-			exitErr = nil
-			return true, nil
-		}
-		return false, nil
-	}); err != nil {
-		return err
-	}
-	if exitErr != nil {
-		return exitErr
-	}
-	return m.WaitPodsReady(namespace, c)
 }
 
 // WaitForJob wait for job execution, follow logs and returns an error if job failed

--- a/client/client.go
+++ b/client/client.go
@@ -255,7 +255,7 @@ type ReadyCheckData struct {
 }
 
 // CheckReady application heath check using ManifestOutputData params
-func (m *K8sClient) CheckReady(namespace string, c *ReadyCheckData) error {
+func (m *K8sClient) CheckReady(namespace string, c *ReadyCheckData, appCount int) error {
 	// wait for the number of enumerated apps to be at least 1 before checking
 	// for ready or we can error out on slow runs or large jobs
 	var exitErr error
@@ -265,8 +265,8 @@ func (m *K8sClient) CheckReady(namespace string, c *ReadyCheckData) error {
 			exitErr = err2
 			return false, nil
 		}
-		log.Debug().Interface("Apps", apps).Int("Count", len(apps)).Msg("Found apps")
-		if len(apps) > 0 {
+		log.Debug().Interface("Apps", apps).Int("Count", len(apps)).Int("Expected", appCount).Msg("Found apps")
+		if len(apps) == appCount {
 			exitErr = nil
 			return true, nil
 		}
@@ -316,6 +316,7 @@ func (m *K8sClient) Apply(manifest string) error {
 		return err
 	}
 	cmd := fmt.Sprintf("kubectl apply -f %s", manifestFile)
+	log.Info().Str("cmd", cmd).Msg("Apply command")
 	return ExecCmd(cmd)
 }
 

--- a/e2e/envs_test.go
+++ b/e2e/envs_test.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/rs/zerolog/log"
 	"github.com/smartcontractkit/chainlink-env/environment"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/chainlink"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/ethereum"
@@ -148,4 +149,24 @@ func TestRemoteRunnerMultipleRunCommands(t *testing.T) {
 	e.AddHelm(chainlink.New(1, nil))
 	err = e.Run()
 	require.NoError(t, err)
+}
+
+func TestRemoteRunnerOneSetupWithMultipeTests(t *testing.T) {
+	t.Parallel()
+	testEnvConfig := getTestEnvConfig(t)
+	e := presets.EVMMinimalLocal(testEnvConfig)
+	err := e.Run()
+	// nolint
+	defer e.Shutdown()
+	require.NoError(t, err)
+	if e.WillUseRemoteRunner() {
+		return
+	}
+
+	t.Run("do one", func(t *testing.T) {
+		log.Info().Str("Test", "One").Msg("Inside test")
+	})
+	t.Run("do two", func(t *testing.T) {
+		log.Info().Str("Test", "One").Msg("Inside test")
+	})
 }

--- a/e2e/envs_test.go
+++ b/e2e/envs_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/smartcontractkit/chainlink-env/environment"
@@ -143,9 +144,6 @@ func TestRemoteRunnerMultipleRunCommands(t *testing.T) {
 	// nolint
 	defer e.Shutdown()
 	require.NoError(t, err)
-	if e.WillUseRemoteRunner() {
-		return
-	}
 	e.AddHelm(chainlink.New(1, nil))
 	err = e.Run()
 	require.NoError(t, err)
@@ -163,10 +161,14 @@ func TestRemoteRunnerOneSetupWithMultipeTests(t *testing.T) {
 		return
 	}
 
+	log.Info().Str("Test", "Before").Msg("Before Tests")
 	t.Run("do one", func(t *testing.T) {
 		log.Info().Str("Test", "One").Msg("Inside test")
+		time.Sleep(1 * time.Second)
 	})
 	t.Run("do two", func(t *testing.T) {
-		log.Info().Str("Test", "One").Msg("Inside test")
+		log.Info().Str("Test", "Two").Msg("Inside test")
+		time.Sleep(1 * time.Second)
 	})
+	log.Info().Str("Test", "After").Msg("After Tests")
 }

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -485,6 +485,7 @@ func (m *Environment) Deploy(manifest string) error {
 func (m *Environment) findPodCountInDeploymentManifest() int {
 	podCount := 0
 	config.JSIIGlobalMu.Lock()
+	defer config.JSIIGlobalMu.Unlock()
 	charts := m.App.Charts()
 	for _, chart := range *charts {
 		json := chart.ToJson()
@@ -507,7 +508,6 @@ func (m *Environment) findPodCountInDeploymentManifest() int {
 			}
 		}
 	}
-	config.JSIIGlobalMu.Unlock()
 	return podCount
 }
 


### PR DESCRIPTION
We can sometimes pull the list of apps and ports to check for ready before all the apps and ports are populated. This forces us to wait for the full list of apps added to helm to be present before starting this logic.