### PR TITLE
Add necessary api groups to the remote runner for chaos experiments

### DIFF
--- a/client/cmd.go
+++ b/client/cmd.go
@@ -10,7 +10,9 @@ import (
 )
 
 func ExecCmd(command string) error {
-	return ExecCmdWithOptions(command, nil)
+	return ExecCmdWithOptions(command, func(m string) {
+		log.Info().Str("Text", m).Msg("Std Pipe")
+	})
 }
 
 // readStdPipe continuously read a pipe from the command
@@ -19,7 +21,6 @@ func readStdPipe(pipe io.ReadCloser, outputFunction func(string)) {
 	scanner.Split(bufio.ScanLines)
 	for scanner.Scan() {
 		m := scanner.Text()
-		log.Trace().Str("Text", m).Msg("Std Pipe")
 		if outputFunction != nil {
 			outputFunction(m)
 		}

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -398,6 +398,7 @@ func (m *Environment) Run() error {
 	}
 	if m.Cfg.JobImage != "" {
 		if err := m.Client.WaitForJob(m.Cfg.Namespace, "remote-test-runner", func(message string) {
+			fmt.Printf("Remote: %s\n", message)
 			found := strings.Contains(message, FAILED_FUND_RETURN)
 			if found {
 				m.Cfg.fundReturnFailed = &found

--- a/environment/runner.go
+++ b/environment/runner.go
@@ -74,6 +74,11 @@ func role(chart cdk8s.Chart, props *Props) {
 						a.Str(""), // this empty line is needed or k8s get really angry
 						a.Str("apps"),
 						a.Str("batch"),
+						a.Str("core"),
+						a.Str("networking.k8s.io"),
+						a.Str("storage.k8s.io"),
+						a.Str("policy"),
+						a.Str("chaos-mesh.org"),
 					},
 					Resources: &[]*string{
 						a.Str("*"),


### PR DESCRIPTION
- Adds missing api groups that are needed by chaos mesh to run.
- Changes the output of exec cmd so we can see what is coming from local vs remote runner.