### PR TITLE
Do not wait for pods readiness if no pods in manifest

### DIFF
--- a/environment/environment.go
+++ b/environment/environment.go
@@ -496,9 +496,10 @@ func (m *Environment) Deploy(manifest string) error {
 	}
 
 	expectedPodCount := m.findPodCountInDeploymentManifest()
-
-	if err := m.Client.WaitPodsReady(m.Cfg.Namespace, m.Cfg.ReadyCheckData, expectedPodCount); err != nil {
-		return err
+	if expectedPodCount > 0 {
+		if err := m.Client.WaitPodsReady(m.Cfg.Namespace, m.Cfg.ReadyCheckData, expectedPodCount); err != nil {
+			return err
+		}
 	}
 	return m.enumerateApps()
 }


### PR DESCRIPTION
This allows to create a namespace without pods which is needed for composable mercury test env https://github.com/smartcontractkit/chainlink/pull/8724