### PR TITLE
Enforce env user and provide a useful error message

### DIFF
--- a/environment/environment.go
+++ b/environment/environment.go
@@ -194,7 +194,11 @@ func (m *Environment) initApp() {
 		YamlOutputType: cdk8s.YamlOutputType_FILE_PER_APP,
 	})
 	m.Cfg.Labels = append(m.Cfg.Labels, "generatedBy=cdk8s")
-	m.Cfg.Labels = append(m.Cfg.Labels, fmt.Sprintf("owner=%s", os.Getenv(config.EnvVarUser)))
+	owner := os.Getenv(config.EnvVarUser)
+	if owner == "" {
+		panic(fmt.Sprintf("missing owner environment variable, please set %s to your name or if you are seeing this in CI please set it to ${{ github.actor }}", config.EnvVarUser))
+	}
+	m.Cfg.Labels = append(m.Cfg.Labels, fmt.Sprintf("owner=%s", owner))
 
 	if os.Getenv(config.EnvVarCLCommitSha) != "" {
 		m.Cfg.Labels = append(m.Cfg.Labels, fmt.Sprintf("commit=%s", os.Getenv(config.EnvVarCLCommitSha)))

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -196,7 +196,7 @@ func (m *Environment) initApp() {
 	m.Cfg.Labels = append(m.Cfg.Labels, "generatedBy=cdk8s")
 	owner := os.Getenv(config.EnvVarUser)
 	if owner == "" {
-		panic(fmt.Sprintf("missing owner environment variable, please set %s to your name or if you are seeing this in CI please set it to ${{ github.actor }}", config.EnvVarUser))
+		log.Fatal().Str(config.EnvVarUser, owner).Msg(fmt.Sprintf("missing owner environment variable, please set %s to your name or if you are seeing this in CI please set it to ${{ github.actor }}", config.EnvVarUser))
 	}
 	m.Cfg.Labels = append(m.Cfg.Labels, fmt.Sprintf("owner=%s", owner))
 


### PR DESCRIPTION
We end up triaging a lot of errors to test runs in the cluster that do not have names associated which makes it difficult to know who to ask questions. This enforces the env user.