### PR TITLE
[TT-245] Enable Running with Custom Ready Conditions

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -97,7 +97,13 @@ func (m *K8sClient) AddLabel(namespace string, selector string, label string) er
 	}
 	for _, pod := range podList.Items {
 		labelPatch := fmt.Sprintf(`[{"op":"add","path":"/metadata/labels/%s","value":"%s" }]`, l[0], l[1])
-		_, err := m.ClientSet.CoreV1().Pods(namespace).Patch(context.Background(), pod.GetName(), types.JSONPatchType, []byte(labelPatch), metaV1.PatchOptions{})
+		_, err := m.ClientSet.CoreV1().Pods(namespace).Patch(
+			context.Background(),
+			pod.GetName(),
+			types.JSONPatchType,
+			[]byte(labelPatch),
+			metaV1.PatchOptions{},
+		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to update labels %s for pod %s", labelPatch, pod.Name)
 		}

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -634,6 +634,15 @@ func (m *Environment) RunCustomReadyConditions(customCheck *client.ReadyCheckDat
 	return nil
 }
 
+// RunUpdated runs the environment and checks for pods with `updated=true` label
+func (m *Environment) RunUpdated(podCount int) error {
+	conds := &client.ReadyCheckData{
+		ReadinessProbeCheckSelector: "updated=true",
+		Timeout:                     10 * time.Minute,
+	}
+	return m.RunCustomReadyConditions(conds, podCount)
+}
+
 // Run deploys or connects to already created environment
 func (m *Environment) Run() error {
 	return m.RunCustomReadyConditions(nil, 0)

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -561,6 +561,7 @@ func (m *Environment) RunCustomReadyConditions(customCheck *client.ReadyCheckDat
 		}))
 	}
 	m.UpdateManifest()
+	m.ChainlinkNodeDetails = []*ChainlinkNodeDetail{} // Resets potentially old details if re-deploying
 	if m.Cfg.DryRun {
 		log.Info().Msg("Dry-run mode, manifest synthesized and saved as tmp-manifest.yaml")
 		return nil

--- a/pkg/helm/chainlink/chainlink.go
+++ b/pkg/helm/chainlink/chainlink.go
@@ -186,7 +186,7 @@ func NewVersioned(index int, helmVersion string, props map[string]any) environme
 	return Chart{
 		Index:   index,
 		Name:    fmt.Sprintf("%s-%d", AppName, index),
-		Path:    "chainlink-qa/chainlink",
+		Path:    "/Users/adamhamrick/Projects/qa-charts/charts/chainlink",
 		Version: helmVersion,
 		Values:  &dp,
 	}

--- a/pkg/helm/chainlink/chainlink.go
+++ b/pkg/helm/chainlink/chainlink.go
@@ -186,7 +186,7 @@ func NewVersioned(index int, helmVersion string, props map[string]any) environme
 	return Chart{
 		Index:   index,
 		Name:    fmt.Sprintf("%s-%d", AppName, index),
-		Path:    "/Users/adamhamrick/Projects/qa-charts/charts/chainlink",
+		Path:    "chainlink-qa/chainlink",
 		Version: helmVersion,
 		Values:  &dp,
 	}


### PR DESCRIPTION
Adds `DeployCustomReadyConditions` and `RunCustomReadyConditions` so that we can check for a `updated=true` label when re-deploying nodes with changes.