### PR TITLE
Return stdout and stderr even if cmd exits with err

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -484,10 +484,7 @@ func (m *K8sClient) ExecuteInPod(namespace, podName, containerName string, comma
 		Stdout: &stdout,
 		Stderr: &stderr,
 	})
-	if err != nil {
-		return []byte{}, []byte{}, err
-	}
-	return stdout.Bytes(), stderr.Bytes(), nil
+	return stdout.Bytes(), stderr.Bytes(), err
 }
 
 func podNames(podItems *v1.PodList) []string {


### PR DESCRIPTION
Previously when a command exited with non-zero status the stdout and stderr was not returned. This change always returns them.