### PR TITLE
[TT-383] Apply default pod annotations to deployment

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -159,8 +159,14 @@ func (m *K8sClient) AddPodsLabels(namespace string, podList *v1.PodList, labels 
 
 // AddPodsAnnotations adds map of annotations to all pods in list
 func (m *K8sClient) AddPodsAnnotations(namespace string, podList *v1.PodList, annotations map[string]string) error {
+	// when applying annotations the key doesn't like `/` characters here but everywhere else it does
+	// replacing it here with ~1
+	fixedAnnotations := make(map[string]string)
+	for k, v := range annotations {
+		fixedAnnotations[strings.ReplaceAll(k, "/", "~1")] = v
+	}
 	for _, pod := range podList.Items {
-		for k, v := range annotations {
+		for k, v := range fixedAnnotations {
 			err := m.AddPodAnnotation(namespace, pod, k, v)
 			if err != nil {
 				return err

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -772,11 +772,7 @@ func (m *Environment) DeployCustomReadyConditions(customCheck *client.ReadyCheck
 	// Attempt to apply default pod annotations even through they are applied in the manifest
 	// as an attempt to add them to any pods that did not have their charts setup to handle the
 	// podAnnotations in their templates.
-	// when applying annotations it doesn't like `/` characters here but everywhere else it does
-	annotations := defaultPodAnnotations
-	annotations["cluster-autoscaler.kubernetes.io~1safe-to-evict"] = annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]
-	delete(annotations, "cluster-autoscaler.kubernetes.io/safe-to-evict")
-	return m.Client.AddPodsAnnotations(m.Cfg.Namespace, podList, annotations)
+	return m.Client.AddPodsAnnotations(m.Cfg.Namespace, podList, defaultPodAnnotations)
 }
 
 // Deploy deploy current manifest and check logs for readiness

--- a/environment/runner.go
+++ b/environment/runner.go
@@ -131,7 +131,8 @@ func job(chart cdk8s.Chart, props *Props) {
 			Spec: &k8s.JobSpec{
 				Template: &k8s.PodTemplateSpec{
 					Metadata: &k8s.ObjectMeta{
-						Labels: props.Labels,
+						Labels:      props.Labels,
+						Annotations: a.ConvertAnnotations(defaultPodAnnotations),
 					},
 					Spec: &k8s.PodSpec{
 						ServiceAccountName: a.Str("default"),

--- a/pkg/alias/alias.go
+++ b/pkg/alias/alias.go
@@ -41,6 +41,15 @@ func ConvertLabels(labels []string) (*map[string]*string, error) {
 	return &cdk8sLabels, nil
 }
 
+// ConvertAnnotations converts a map[string]string to a *map[string]*string
+func ConvertAnnotations(annotations map[string]string) *map[string]*string {
+	a := make(map[string]*string)
+	for k, v := range annotations {
+		a[k] = Str(v)
+	}
+	return &a
+}
+
 // EnvVarStr quick shortcut for string/string key/value var
 func EnvVarStr(k, v string) *k8s.EnvVar {
 	return &k8s.EnvVar{


### PR DESCRIPTION
We were applying the annotations after the pods booted up but there was a small time frame where the autoscaler could start a rebalancing of the pod before we got our annotation on it and somehow would end up with the pod never receiving the annotation. This guarantees pods that have charts that are setup to have podAnnotations injected via their values will get the annotations on boot. We also still attempt to add the annotations after the fact for any charts that aren't setup correctly.