### PR TITLE
Don't force map[string]string on underlying helm values input

### DIFF
--- a/environment/environment.go
+++ b/environment/environment.go
@@ -460,10 +460,10 @@ func (m *Environment) AddHelm(chart ConnectedChart) *Environment {
 	config.JSIIGlobalMu.Lock()
 	defer config.JSIIGlobalMu.Unlock()
 
-	values := &map[string]interface{}{
-		"tolerations":    m.Cfg.Tolerations,
-		"nodeSelector":   m.Cfg.NodeSelector,
-		"podAnnotations": defaultPodAnnotations,
+	values := &map[string]any{
+		"tolerations":    a.SliceMapStringStringToSliceMapStringAny(m.Cfg.Tolerations),
+		"nodeSelector":   a.MapStringStringToMapStringAny(m.Cfg.NodeSelector),
+		"podAnnotations": a.MapStringStringToMapStringAny(defaultPodAnnotations),
 	}
 	config.MustMerge(values, chart.GetValues())
 	log.Trace().

--- a/pkg/alias/alias.go
+++ b/pkg/alias/alias.go
@@ -50,6 +50,24 @@ func ConvertAnnotations(annotations map[string]string) *map[string]*string {
 	return &a
 }
 
+// SliceMapStringStringToSliceMapStringAny converts a []map[string]string to a []map[string]any
+func SliceMapStringStringToSliceMapStringAny(originalSlice []map[string]string) []map[string]any {
+	newSlice := make([]map[string]any, len(originalSlice))
+	for i, m := range originalSlice {
+		newSlice[i] = MapStringStringToMapStringAny(m)
+	}
+	return newSlice
+}
+
+// MapStringStringToMapStringAny converts a map[string]string to a map[string]any
+func MapStringStringToMapStringAny(originalMap map[string]string) map[string]any {
+	newMap := make(map[string]any, len(originalMap))
+	for k, v := range originalMap {
+		newMap[k] = v
+	}
+	return newMap
+}
+
 // EnvVarStr quick shortcut for string/string key/value var
 func EnvVarStr(k, v string) *k8s.EnvVar {
 	return &k8s.EnvVar{


### PR DESCRIPTION
This can prevent anyone that might want a deeper structure for these in their values.yaml.