### PR TITLE
Remove the deprecated ModifyHelm function in favor of the ReplaceHelm function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,10 @@ test_e2e:
 	go test ./e2e/local-runner -count 1 -test.parallel=12 -v $(args)
 
 test_e2e_ci:
-	go test ./e2e/local-runner -count 1 -v -test.parallel=12 -test.timeout=1h -json 2>&1 | tee /tmp/gotest.log | gotestfmt
+	go test ./e2e/local-runner -count 1 -v -test.parallel=13 -test.timeout=1h -json 2>&1 | tee /tmp/gotest.log | gotestfmt
 
 test_e2e_ci_remote_runner:
-	go test ./e2e/remote-runner -count 1 -v -test.parallel=14 -test.timeout=1h -json 2>&1 | tee /tmp/remoterunnergotest.log | gotestfmt
+	go test ./e2e/remote-runner -count 1 -v -test.parallel=15 -test.timeout=1h -json 2>&1 | tee /tmp/remoterunnergotest.log | gotestfmt
 
 .PHONY: examples
 examples:

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -121,9 +121,9 @@ type ConnectedChart interface {
 	// GetPath get Helm chart path, repo or local path
 	GetPath() string
 	// GetProps get code props if it's typed environment
-	GetProps() interface{}
+	GetProps() any
 	// GetValues get values.yml props as map, if it's Helm
-	GetValues() *map[string]interface{}
+	GetValues() *map[string]any
 	// ExportData export deployment part data in the env
 	ExportData(e *Environment) error
 }
@@ -167,9 +167,9 @@ func main() {
 		RemoveOnInterrupt: true,
 	}).
 		AddHelm(deployment_part.New(nil)).
-		AddHelm(chainlink.New(0, map[string]interface{}{
+		AddHelm(chainlink.New(0, map[string]any{
 			"replicas": 5,
-			"env": map[string]interface{}{
+			"env": map[string]any{
 				"SOLANA_ENABLED":              "true",
 				"EVM_ENABLED":                 "false",
 				"EVM_RPC_ENABLED":             "false",
@@ -207,9 +207,9 @@ type ConnectedChart interface {
 	// GetPath get Helm chart path, repo or local path
 	GetPath() string
 	// GetProps get code props if it's typed environment
-	GetProps() interface{}
+	GetProps() any
 	// GetValues get values.yml props as map, if it's Helm
-	GetValues() *map[string]interface{}
+	GetValues() *map[string]any
 	// ExportData export deployment part data in the env
 	ExportData(e *Environment) error
 }
@@ -230,7 +230,7 @@ func main() {
   e := environment.New(nil).
     AddChart(deployment_part_cdk8s.New(&deployment_part_cdk8s.Props{})).
     AddHelm(ethereum.New(nil)).
-          AddHelm(chainlink.New(0, map[string]interface{}{
+          AddHelm(chainlink.New(0, map[string]any{
             "replicas": 2,
           }))
   if err := e.Run(); err != nil {
@@ -322,7 +322,7 @@ func main() {
 			HttpURL: "http://geth:8544",
 		})).
 		AddHelm(ethereum.New(nil)).
-		AddHelm(chainlink.New(0, map[string]interface{}{
+		AddHelm(chainlink.New(0, map[string]any{
 			"replicas": 1,
 		}))
 	err := e.Run()
@@ -335,7 +335,7 @@ func main() {
 			HttpURL: "http://geth:9000",
 		})).
 		AddHelm(ethereum.New(nil)).
-		AddHelm(chainlink.New(0, map[string]interface{}{
+		AddHelm(chainlink.New(0, map[string]any{
 			"replicas": 1,
 		})).
 		Run()
@@ -369,7 +369,7 @@ func main() {
 		AddHelm(mockservercfg.New(nil)).
 		AddHelm(mockserver.New(nil)).
 		AddHelm(ethereum.New(nil)).
-		AddHelm(chainlink.New(0, map[string]interface{}{
+		AddHelm(chainlink.New(0, map[string]any{
 			"replicas": 1,
 		}))
 	err := e.Run()
@@ -378,10 +378,14 @@ func main() {
 	}
 	e.Cfg.KeepConnection = true
 	e.Cfg.RemoveOnInterrupt = true
-	err = e.
-		ModifyHelm("chainlink-0", chainlink.New(0, map[string]interface{}{
+	e, err = e.
+		ReplaceHelm("chainlink-0", chainlink.New(0, map[string]any{
 			"replicas": 2,
-		})).Run()
+		}))
+	if err != nil {
+		panic(err)
+	}
+	err = e.Run()
 	if err != nil {
 		panic(err)
 	}

--- a/client/chaos.go
+++ b/client/chaos.go
@@ -43,7 +43,7 @@ func (c *Chaos) Run(app cdk8s.App, id string, resource string) (string, error) {
 	config.JSIIGlobalMu.Unlock()
 	log.Trace().Str("Raw", manifest).Msg("Manifest")
 	c.ResourceByName[id] = resource
-	if err := c.Client.Apply(manifest); err != nil {
+	if err := c.Client.Apply(manifest, c.Namespace); err != nil {
 		return id, err
 	}
 	if err := c.checkForPodsExistence(app); err != nil {

--- a/client/forwarder.go
+++ b/client/forwarder.go
@@ -90,8 +90,8 @@ func (m *Forwarder) forwardPodPorts(pod v1.Pod, namespaceName string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	namedPorts := m.podPortsByName(pod, forwardedPorts)
-	if pod.Labels["app"] != "" {
-		m.Info[fmt.Sprintf("%s:%s", pod.Labels["app"], pod.Labels["instance"])] = namedPorts
+	if pod.Labels[AppLabel] != "" {
+		m.Info[fmt.Sprintf("%s:%s", pod.Labels[AppLabel], pod.Labels["instance"])] = namedPorts
 	}
 	return nil
 }
@@ -111,8 +111,8 @@ func (m *Forwarder) collectPodPorts(pod v1.Pod) error {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if pod.Labels["app"] != "" {
-		m.Info[fmt.Sprintf("%s:%s", pod.Labels["app"], pod.Labels["instance"])] = namedPorts
+	if pod.Labels[AppLabel] != "" {
+		m.Info[fmt.Sprintf("%s:%s", pod.Labels[AppLabel], pod.Labels["instance"])] = namedPorts
 	}
 	return nil
 }

--- a/e2e/common/test_common.go
+++ b/e2e/common/test_common.go
@@ -104,7 +104,7 @@ func TestConnectWithoutManifest(t *testing.T) {
 		// deploy environment to use as an existing one for the test
 		existingEnv.Cfg.JobImage = ""
 		existingEnv.AddHelm(ethereum.New(nil)).
-			AddHelm(chainlink.New(0, map[string]interface{}{
+			AddHelm(chainlink.New(0, map[string]any{
 				"replicas": 1,
 			}))
 		err := existingEnv.Run()
@@ -126,7 +126,7 @@ func TestConnectWithoutManifest(t *testing.T) {
 	testEnv := environment.New(testEnvConfig)
 	l.Info().Msgf("Testing Env Namespace %s", testEnv.Cfg.Namespace)
 	err := testEnv.AddHelm(ethereum.New(nil)).
-		AddHelm(chainlink.New(0, map[string]interface{}{
+		AddHelm(chainlink.New(0, map[string]any{
 			"replicas": 1,
 		})).
 		Run()
@@ -260,7 +260,7 @@ func TestWithChaos(t *testing.T) {
 	testEnvConfig := GetTestEnvConfig(t)
 	e := environment.New(testEnvConfig).
 		AddHelm(ethereum.New(nil)).
-		AddHelm(chainlink.New(0, map[string]interface{}{
+		AddHelm(chainlink.New(0, map[string]any{
 			"replicas": 1,
 		}))
 	err := e.Run()
@@ -322,8 +322,8 @@ func TestEmptyEnvironmentStartup(t *testing.T) {
 func TestRolloutRestart(t *testing.T, statefulSet bool) {
 	t.Parallel()
 	testEnvConfig := GetTestEnvConfig(t)
-	cd, err := chainlink.NewDeployment(5, map[string]interface{}{
-		"db": map[string]interface{}{
+	cd, err := chainlink.NewDeployment(5, map[string]any{
+		"db": map[string]any{
 			"stateful": true,
 			"capacity": "1Gi",
 		},
@@ -357,13 +357,13 @@ func TestReplaceHelm(t *testing.T) {
 	t.Parallel()
 	testEnvConfig := GetTestEnvConfig(t)
 	cd, err := chainlink.NewDeployment(1, map[string]any{
-		"chainlink": map[string]interface{}{
-			"resources": map[string]interface{}{
-				"requests": map[string]interface{}{
-					"cpu": "1000m",
+		"chainlink": map[string]any{
+			"resources": map[string]any{
+				"requests": map[string]any{
+					"cpu": "350m",
 				},
-				"limits": map[string]interface{}{
-					"cpu": "1000m",
+				"limits": map[string]any{
+					"cpu": "350m",
 				},
 			},
 		},
@@ -380,13 +380,13 @@ func TestReplaceHelm(t *testing.T) {
 	})
 	require.NoError(t, err)
 	cd, err = chainlink.NewDeployment(1, map[string]any{
-		"chainlink": map[string]interface{}{
-			"resources": map[string]interface{}{
-				"requests": map[string]interface{}{
-					"cpu": "950m",
+		"chainlink": map[string]any{
+			"resources": map[string]any{
+				"requests": map[string]any{
+					"cpu": "345m",
 				},
-				"limits": map[string]interface{}{
-					"cpu": "950m",
+				"limits": map[string]any{
+					"cpu": "345m",
 				},
 			},
 		},

--- a/e2e/common/test_common.go
+++ b/e2e/common/test_common.go
@@ -253,7 +253,7 @@ func TestWithChaos(t *testing.T) {
 	}{
 		chaos.NewFailPods,
 		&chaos.Props{
-			LabelsSelector: &map[string]*string{"app": a.Str(appLabel)},
+			LabelsSelector: &map[string]*string{client.AppLabel: a.Str(appLabel)},
 			DurationStr:    "30s",
 		},
 	}

--- a/e2e/common/test_common.go
+++ b/e2e/common/test_common.go
@@ -342,7 +342,7 @@ func TestRolloutRestart(t *testing.T, statefulSet bool) {
 	})
 
 	if statefulSet {
-		err = e.RolloutStatefulSets()
+		err = e.Client.RolloutStatefulSets(e.Cfg.Namespace)
 		require.NoError(t, err, "failed to rollout statefulsets")
 	} else {
 		err = e.Client.RolloutRestartBySelector(e.Cfg.Namespace, "deployment", "envType=chainlink-env-test")

--- a/e2e/local-runner/envs_test.go
+++ b/e2e/local-runner/envs_test.go
@@ -53,3 +53,7 @@ func TestRolloutRestartUpdate(t *testing.T) {
 func TestRolloutRestartBySelector(t *testing.T) {
 	common.TestRolloutRestart(t, false)
 }
+
+func TestReplaceHelm(t *testing.T) {
+	common.TestReplaceHelm(t)
+}

--- a/e2e/remote-runner/remote_runner_envs_test.go
+++ b/e2e/remote-runner/remote_runner_envs_test.go
@@ -78,7 +78,7 @@ func TestRemoteRunnerOneSetupWithMultipeTests(t *testing.T) {
 		AddHelm(mockservercfg.New(nil)).
 		AddHelm(mockserver.New(nil)).
 		AddHelm(ethChart).
-		AddHelm(chainlink.New(0, map[string]interface{}{
+		AddHelm(chainlink.New(0, map[string]any{
 			"replicas": 5,
 		}))
 	err := e.Run()

--- a/e2e/remote-runner/remote_runner_envs_test.go
+++ b/e2e/remote-runner/remote_runner_envs_test.go
@@ -143,3 +143,7 @@ func TestRolloutRestartUpdate(t *testing.T) {
 func TestRolloutRestartBySelector(t *testing.T) {
 	common.TestRolloutRestart(t, false)
 }
+
+func TestReplaceHelm(t *testing.T) {
+	common.TestReplaceHelm(t)
+}

--- a/environment/artifacts.go
+++ b/environment/artifacts.go
@@ -64,7 +64,7 @@ func (a *Artifacts) writePodArtifacts(testDir string) error {
 		log.Info().
 			Str("Pod", pod.Name).
 			Msg("Writing pod artifacts")
-		appName := pod.Labels["app"]
+		appName := pod.Labels[client.AppLabel]
 		instance := pod.Labels["instance"]
 		appDir := filepath.Join(testDir, fmt.Sprintf("%s_%s", appName, instance))
 		if err := MkdirIfNotExists(appDir); err != nil {

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -685,7 +685,7 @@ func (m *Environment) Run() error {
 }
 
 func (m *Environment) enumerateApps() error {
-	apps, err := m.Client.UniqueLabels(m.Cfg.Namespace, "app")
+	apps, err := m.Client.UniqueLabels(m.Cfg.Namespace, client.AppLabel)
 	if err != nil {
 		return err
 	}
@@ -795,7 +795,7 @@ func getReplicaCount(spec map[string]any) int {
 	if m == nil {
 		return 0
 	}
-	l := m["app"]
+	l := m[client.AppLabel]
 	if l == nil {
 		return 0
 	}

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -383,40 +383,6 @@ func (m *Environment) ReplaceHelm(name string, chart ConnectedChart) (*Environme
 	return m, nil
 }
 
-// ModifyHelm entirely replaces a helm chart with a new one
-//
-// Deprecated: use ReplaceHelm instead to avoid silent errors
-func (m *Environment) ModifyHelm(name string, chart ConnectedChart) *Environment {
-	if m.err != nil {
-		return m
-	}
-	config.JSIIGlobalMu.Lock()
-	defer config.JSIIGlobalMu.Unlock()
-	if err := m.removeChart(name); err != nil {
-		return nil
-	}
-	if m.Cfg.JobImage != "" || !chart.IsDeploymentNeeded() {
-		return nil
-	}
-	log.Trace().
-		Str("Chart", chart.GetName()).
-		Str("Path", chart.GetPath()).
-		Interface("Props", chart.GetProps()).
-		Interface("Values", chart.GetValues()).
-		Msg("Chart deployment values")
-	cdk8s.NewHelm(m.root, a.Str(name), &cdk8s.HelmProps{
-		Chart: a.Str(chart.GetPath()),
-		HelmFlags: &[]*string{
-			a.Str("--namespace"),
-			a.Str(m.Cfg.Namespace),
-		},
-		ReleaseName: a.Str(name),
-		Values:      chart.GetValues(),
-	})
-	m.Charts = append(m.Charts, chart)
-	return m
-}
-
 // UpdateHelm update a helm chart with new values. The pod will launch with an `updated=true` label if it's a Chainlink node.
 // Note: If you're modifying ConfigMap values, you'll probably need to use RollOutStatefulSets to apply the changes to the pods.
 // https://stackoverflow.com/questions/57356521/rollingupdate-for-stateful-set-doesnt-restart-pods-and-changes-from-updated-con
@@ -460,7 +426,7 @@ func (m *Environment) AddHelm(chart ConnectedChart) *Environment {
 	config.JSIIGlobalMu.Lock()
 	defer config.JSIIGlobalMu.Unlock()
 
-	values := &map[string]interface{}{
+	values := &map[string]any{
 		"tolerations":    m.Cfg.Tolerations,
 		"nodeSelector":   m.Cfg.NodeSelector,
 		"podAnnotations": defaultPodAnnotations,
@@ -805,11 +771,11 @@ func (m *Environment) findPodCountInDeploymentManifest() int {
 			continue
 		}
 		for _, j := range *json {
-			m := j.(map[string]interface{})
+			m := j.(map[string]any)
 			// if the kind is a deployment then we want to see if it has replicas to count towards the app count
 			kind := m["kind"].(string)
 			if kind == "Deployment" || kind == "StatefulSet" {
-				podCount += getReplicaCount(m["spec"].(map[string]interface{}))
+				podCount += getReplicaCount(m["spec"].(map[string]any))
 			}
 		}
 
@@ -817,15 +783,15 @@ func (m *Environment) findPodCountInDeploymentManifest() int {
 	return podCount
 }
 
-func getReplicaCount(spec map[string]interface{}) int {
+func getReplicaCount(spec map[string]any) int {
 	if spec == nil {
 		return 0
 	}
-	s := spec["selector"].(map[string]interface{})
+	s := spec["selector"].(map[string]any)
 	if s == nil {
 		return 0
 	}
-	m := s["matchLabels"].(map[string]interface{})
+	m := s["matchLabels"].(map[string]any)
 	if m == nil {
 		return 0
 	}
@@ -853,8 +819,8 @@ type CoverageProfileParams struct {
 	SkipFilePatterns  []string `form:"skipfile" json:"skipfile"`
 }
 
-func (m *Environment) getCoverageList() (map[string]interface{}, error) {
-	var servicesMap map[string]interface{}
+func (m *Environment) getCoverageList() (map[string]any, error) {
+	var servicesMap map[string]any
 	resp, err := m.httpClient.R().
 		SetResult(&servicesMap).
 		Get("v1/cover/list")

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -315,7 +315,7 @@ func (m *Environment) initApp() error {
 		},
 	})
 	m.CurrentManifest = *m.App.SynthYaml()
-	return m.Client.Apply(m.CurrentManifest)
+	return m.Client.Apply(m.CurrentManifest, m.Cfg.Namespace)
 }
 
 // AddChart adds a chart to the deployment
@@ -710,7 +710,7 @@ func (m *Environment) DeployCustomReadyConditions(customCheck *client.ReadyCheck
 		}
 		return nil
 	}
-	if err := m.Client.Apply(m.CurrentManifest); err != nil {
+	if err := m.Client.Apply(m.CurrentManifest, m.Cfg.Namespace); err != nil {
 		return err
 	}
 	if int64(m.Cfg.UpdateWaitInterval) != 0 {

--- a/examples/concurrent/env_test.go
+++ b/examples/concurrent/env_test.go
@@ -24,10 +24,12 @@ func TestConcurrentEnvs(t *testing.T) {
 		defer e.Shutdown()
 		err := e.Run()
 		require.NoError(t, err)
-		err = e.
-			ModifyHelm("chainlink-0", chainlink.New(0, map[string]interface{}{
+		e, err = e.
+			ReplaceHelm("chainlink-0", chainlink.New(0, map[string]any{
 				"replicas": 2,
-			})).Run()
+			}))
+		require.NoError(t, err)
+		err = e.Run()
 		require.NoError(t, err)
 	})
 }

--- a/examples/modify_helm/env.go
+++ b/examples/modify_helm/env.go
@@ -18,7 +18,7 @@ func main() {
 		AddHelm(mockservercfg.New(nil)).
 		AddHelm(mockserver.New(nil)).
 		AddHelm(ethereum.New(nil)).
-		AddHelm(chainlink.New(0, map[string]interface{}{
+		AddHelm(chainlink.New(0, map[string]any{
 			"replicas": 1,
 		}))
 	err := e.Run()
@@ -27,10 +27,14 @@ func main() {
 	}
 	e.Cfg.KeepConnection = true
 	e.Cfg.RemoveOnInterrupt = true
-	err = e.
-		ModifyHelm("chainlink-0", chainlink.New(0, map[string]interface{}{
+	e, err = e.
+		ReplaceHelm("chainlink-0", chainlink.New(0, map[string]any{
 			"replicas": 2,
-		})).Run()
+		}))
+	if err != nil {
+		panic(err)
+	}
+	err = e.Run()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fixes a bug inherent in how we wait for pods to be ready as well. When replacing a pod with ReplaceHelm we can run into the situation where both the old pod and the new pod are present and in a ready state which our framework didn't handle. This state is usually only present for a second or two. We now require the pods to all be ready for 3 consecutive checks which catches cases like this.