### PR TITLE
Pass context to exec command

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -334,14 +334,14 @@ func (m *K8sClient) RolloutStatefulSets(namespace string) error {
 	for _, s := range sts.Items {
 		cmd := fmt.Sprintf("kubectl rollout restart statefulset %s --namespace %s", s.Name, namespace)
 		log.Info().Str("Command", cmd).Msg("Applying StatefulSet rollout")
-		if err := ExecCmd(cmd); err != nil {
+		if err := ExecCmd(context.Background(), cmd); err != nil {
 			return err
 		}
 
 		// wait for the rollout to be complete
 		scmd := fmt.Sprintf("kubectl rollout status statefulset %s --namespace %s", s.Name, namespace)
 		log.Info().Str("Command", scmd).Msg("Waiting for StatefulSet rollout to finish")
-		if err := ExecCmd(scmd); err != nil {
+		if err := ExecCmd(context.Background(), scmd); err != nil {
 			return err
 		}
 	}
@@ -352,13 +352,13 @@ func (m *K8sClient) RolloutStatefulSets(namespace string) error {
 func (m *K8sClient) RolloutRestartBySelector(namespace string, resource string, selector string) error {
 	cmd := fmt.Sprintf("kubectl --namespace %s rollout restart -l %s %s", namespace, selector, resource)
 	log.Info().Str("Command", cmd).Msg("rollout restart by selector")
-	if err := ExecCmd(cmd); err != nil {
+	if err := ExecCmd(context.Background(), cmd); err != nil {
 		return err
 	}
 	// wait for the rollout to be complete
 	scmd := fmt.Sprintf("kubectl --namespace %s rollout status -l %s %s", namespace, selector, resource)
 	log.Info().Str("Command", scmd).Msg("Waiting for StatefulSet rollout to finish")
-	return ExecCmd(scmd)
+	return ExecCmd(context.Background(), scmd)
 }
 
 // ReadyCheckData data to check if selected pods are running and all containers are ready ( readiness check ) are ready
@@ -371,7 +371,7 @@ type ReadyCheckData struct {
 func (m *K8sClient) WaitForJob(namespaceName string, jobName string, fundReturnStatus func(string)) error {
 	cmd := fmt.Sprintf("kubectl --namespace %s logs --follow job/%s", namespaceName, jobName)
 	log.Info().Str("Job", jobName).Str("cmd", cmd).Msg("Waiting for job to complete")
-	if err := ExecCmdWithOptions(cmd, fundReturnStatus); err != nil {
+	if err := ExecCmdWithOptions(context.Background(), cmd, fundReturnStatus); err != nil {
 		return err
 	}
 	var exitErr error
@@ -404,12 +404,12 @@ func (m *K8sClient) Apply(manifest string) error {
 	}
 	cmd := fmt.Sprintf("kubectl apply -f %s", manifestFile)
 	log.Debug().Str("cmd", cmd).Msg("Apply command")
-	return ExecCmd(cmd)
+	return ExecCmd(context.Background(), cmd)
 }
 
 // DeleteResource deletes resource
 func (m *K8sClient) DeleteResource(namespace string, resource string, instance string) error {
-	return ExecCmd(fmt.Sprintf("kubectl delete %s %s --namespace %s", resource, instance, namespace))
+	return ExecCmd(context.Background(), fmt.Sprintf("kubectl delete %s %s --namespace %s", resource, instance, namespace))
 }
 
 // Create creating a manifest to a currently connected k8s context
@@ -420,7 +420,7 @@ func (m *K8sClient) Create(manifest string) error {
 		return err
 	}
 	cmd := fmt.Sprintf("kubectl create -f %s", manifestFile)
-	return ExecCmd(cmd)
+	return ExecCmd(context.Background(), cmd)
 }
 
 // DryRun generates manifest and writes it in a file

--- a/client/cmd.go
+++ b/client/cmd.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"os/exec"
 	"strings"
@@ -9,8 +10,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func ExecCmd(command string) error {
-	return ExecCmdWithOptions(command, func(m string) {
+func ExecCmd(ctx context.Context, command string) error {
+	return ExecCmdWithOptions(ctx, command, func(m string) {
 		log.Debug().Str("Text", m).Msg("Std Pipe")
 	})
 }
@@ -27,9 +28,9 @@ func readStdPipe(pipe io.ReadCloser, outputFunction func(string)) {
 	}
 }
 
-func ExecCmdWithOptions(command string, outputFunction func(string)) error {
+func ExecCmdWithOptions(ctx context.Context, command string, outputFunction func(string)) error {
 	c := strings.Split(command, " ")
-	cmd := exec.Command(c[0], c[1:]...)
+	cmd := exec.CommandContext(ctx, c[0], c[1:]...)
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		return err

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -1,6 +1,7 @@
 package environment
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -522,7 +523,7 @@ func (m *Environment) PullOCIChart(chart ConnectedChart) (string, error) {
 		return "", fmt.Errorf(ErrInvalidOCI, chart.GetPath())
 	}
 	log.Info().Str("CMD", cmd).Msg("Running helm cmd")
-	if err := client.ExecCmd(cmd); err != nil {
+	if err := client.ExecCmd(context.Background(), cmd); err != nil {
 		return "", fmt.Errorf(ErrOCIPull, chart.GetPath())
 	}
 	localChartPath := fmt.Sprintf("%s/%s/", chartDir, chartName)


### PR DESCRIPTION
When using exec.CommandContext the cmd can be killed by cancelling the context. This is required to kill long running commands like `kubectl logs --follow`.