### PR TITLE
Context Timeout for kubectl calls that don't have a set timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,10 @@ test_e2e:
 	go test ./e2e/local-runner -count 1 -test.parallel=12 -v $(args)
 
 test_e2e_ci:
-	go test ./e2e/local-runner -count 1 -v -test.parallel=13 -test.timeout=1h -json 2>&1 | tee /tmp/gotest.log | gotestfmt
+	go test ./e2e/local-runner -count 1 -v -test.parallel=14 -test.timeout=1h -json 2>&1 | tee /tmp/gotest.log | gotestfmt
 
 test_e2e_ci_remote_runner:
-	go test ./e2e/remote-runner -count 1 -v -test.parallel=15 -test.timeout=1h -json 2>&1 | tee /tmp/remoterunnergotest.log | gotestfmt
+	go test ./e2e/remote-runner -count 1 -v -test.parallel=16 -test.timeout=1h -json 2>&1 | tee /tmp/remoterunnergotest.log | gotestfmt
 
 .PHONY: examples
 examples:

--- a/client/chaos.go
+++ b/client/chaos.go
@@ -43,7 +43,7 @@ func (c *Chaos) Run(app cdk8s.App, id string, resource string) (string, error) {
 	config.JSIIGlobalMu.Unlock()
 	log.Trace().Str("Raw", manifest).Msg("Manifest")
 	c.ResourceByName[id] = resource
-	if err := c.Client.Apply(manifest, c.Namespace, context.Background()); err != nil {
+	if err := c.Client.Apply(context.Background(), manifest, c.Namespace); err != nil {
 		return id, err
 	}
 	if err := c.checkForPodsExistence(app); err != nil {

--- a/client/chaos.go
+++ b/client/chaos.go
@@ -43,7 +43,7 @@ func (c *Chaos) Run(app cdk8s.App, id string, resource string) (string, error) {
 	config.JSIIGlobalMu.Unlock()
 	log.Trace().Str("Raw", manifest).Msg("Manifest")
 	c.ResourceByName[id] = resource
-	if err := c.Client.Apply(manifest, c.Namespace); err != nil {
+	if err := c.Client.Apply(manifest, c.Namespace, context.Background()); err != nil {
 		return id, err
 	}
 	if err := c.checkForPodsExistence(app); err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -334,7 +334,7 @@ func (m *K8sClient) RemoveNamespace(namespace string) error {
 }
 
 // RolloutStatefulSets applies "rollout statefulset" to all existing statefulsets in that namespace
-func (m *K8sClient) RolloutStatefulSets(namespace string, ctx context.Context) error {
+func (m *K8sClient) RolloutStatefulSets(ctx context.Context, namespace string) error {
 	stsClient := m.ClientSet.AppsV1().StatefulSets(namespace)
 	sts, err := stsClient.List(context.Background(), metaV1.ListOptions{})
 	if err != nil {
@@ -360,7 +360,7 @@ func (m *K8sClient) RolloutStatefulSets(namespace string, ctx context.Context) e
 }
 
 // RolloutRestartBySelector rollouts and restarts object by selector
-func (m *K8sClient) RolloutRestartBySelector(namespace string, resource string, selector string, ctx context.Context) error {
+func (m *K8sClient) RolloutRestartBySelector(ctx context.Context, namespace, resource, selector string) error {
 	cmd := fmt.Sprintf("kubectl --namespace %s rollout restart -l %s %s", namespace, selector, resource)
 	log.Info().Str("Command", cmd).Msg("rollout restart by selector")
 	if err := ExecCmdWithContext(ctx, cmd); err != nil {
@@ -406,7 +406,7 @@ func (m *K8sClient) WaitForJob(namespaceName string, jobName string, fundReturnS
 	return exitErr
 }
 
-func (m *K8sClient) WaitForDeploymentsAvailable(namespace string, ctx context.Context) error {
+func (m *K8sClient) WaitForDeploymentsAvailable(ctx context.Context, namespace string) error {
 	deployments, err := m.ClientSet.AppsV1().Deployments(namespace).List(context.Background(), metaV1.ListOptions{})
 	if err != nil {
 		return err
@@ -424,7 +424,7 @@ func (m *K8sClient) WaitForDeploymentsAvailable(namespace string, ctx context.Co
 }
 
 // Apply applying a manifest to a currently connected k8s context
-func (m *K8sClient) Apply(manifest, namespace string, ctx context.Context) error {
+func (m *K8sClient) Apply(ctx context.Context, manifest, namespace string) error {
 	manifestFile := fmt.Sprintf(TempDebugManifest, uuid.NewString())
 	log.Info().Str("File", manifestFile).Msg("Applying manifest")
 	if err := os.WriteFile(manifestFile, []byte(manifest), os.ModePerm); err != nil {
@@ -435,7 +435,7 @@ func (m *K8sClient) Apply(manifest, namespace string, ctx context.Context) error
 	if err := ExecCmdWithContext(ctx, cmd); err != nil {
 		return err
 	}
-	return m.WaitForDeploymentsAvailable(namespace, ctx)
+	return m.WaitForDeploymentsAvailable(ctx, namespace)
 }
 
 // DeleteResource deletes resource

--- a/client/client.go
+++ b/client/client.go
@@ -334,7 +334,7 @@ func (m *K8sClient) RemoveNamespace(namespace string) error {
 }
 
 // RolloutStatefulSets applies "rollout statefulset" to all existing statefulsets in that namespace
-func (m *K8sClient) RolloutStatefulSets(namespace string) error {
+func (m *K8sClient) RolloutStatefulSets(namespace string, ctx context.Context) error {
 	stsClient := m.ClientSet.AppsV1().StatefulSets(namespace)
 	sts, err := stsClient.List(context.Background(), metaV1.ListOptions{})
 	if err != nil {
@@ -343,7 +343,7 @@ func (m *K8sClient) RolloutStatefulSets(namespace string) error {
 	for _, s := range sts.Items {
 		cmd := fmt.Sprintf("kubectl rollout restart statefulset %s --namespace %s", s.Name, namespace)
 		log.Info().Str("Command", cmd).Msg("Applying StatefulSet rollout")
-		if err := ExecCmd(cmd); err != nil {
+		if err := ExecCmdWithContext(ctx, cmd); err != nil {
 			return err
 		}
 	}
@@ -352,7 +352,7 @@ func (m *K8sClient) RolloutStatefulSets(namespace string) error {
 		// wait for the rollout to be complete
 		scmd := fmt.Sprintf("kubectl rollout status statefulset %s --namespace %s", s.Name, namespace)
 		log.Info().Str("Command", scmd).Msg("Waiting for StatefulSet rollout to finish")
-		if err := ExecCmd(scmd); err != nil {
+		if err := ExecCmdWithContext(ctx, scmd); err != nil {
 			return err
 		}
 	}
@@ -360,16 +360,16 @@ func (m *K8sClient) RolloutStatefulSets(namespace string) error {
 }
 
 // RolloutRestartBySelector rollouts and restarts object by selector
-func (m *K8sClient) RolloutRestartBySelector(namespace string, resource string, selector string) error {
+func (m *K8sClient) RolloutRestartBySelector(namespace string, resource string, selector string, ctx context.Context) error {
 	cmd := fmt.Sprintf("kubectl --namespace %s rollout restart -l %s %s", namespace, selector, resource)
 	log.Info().Str("Command", cmd).Msg("rollout restart by selector")
-	if err := ExecCmd(cmd); err != nil {
+	if err := ExecCmdWithContext(ctx, cmd); err != nil {
 		return err
 	}
 	// wait for the rollout to be complete
 	waitCmd := fmt.Sprintf("kubectl --namespace %s rollout status -l %s %s", namespace, selector, resource)
 	log.Info().Str("Command", waitCmd).Msg("Waiting for StatefulSet rollout to finish")
-	return ExecCmd(waitCmd)
+	return ExecCmdWithContext(ctx, waitCmd)
 }
 
 // ReadyCheckData data to check if selected pods are running and all containers are ready ( readiness check ) are ready
@@ -382,7 +382,7 @@ type ReadyCheckData struct {
 func (m *K8sClient) WaitForJob(namespaceName string, jobName string, fundReturnStatus func(string)) error {
 	cmd := fmt.Sprintf("kubectl --namespace %s logs --follow job/%s", namespaceName, jobName)
 	log.Info().Str("Job", jobName).Str("cmd", cmd).Msg("Waiting for job to complete")
-	if err := ExecCmdWithOptions(cmd, fundReturnStatus); err != nil {
+	if err := ExecCmdWithOptions(context.Background(), cmd, fundReturnStatus); err != nil {
 		return err
 	}
 	var exitErr error
@@ -406,17 +406,17 @@ func (m *K8sClient) WaitForJob(namespaceName string, jobName string, fundReturnS
 	return exitErr
 }
 
-func (m *K8sClient) WaitForDeploymentsAvailable(namespace string) error {
+func (m *K8sClient) WaitForDeploymentsAvailable(namespace string, ctx context.Context) error {
 	deployments, err := m.ClientSet.AppsV1().Deployments(namespace).List(context.Background(), metaV1.ListOptions{})
 	if err != nil {
 		return err
 	}
-	log.Info().Int("Number", len(deployments.Items)).Msg("Deployments found")
+	log.Debug().Int("Number", len(deployments.Items)).Msg("Deployments found")
 	for _, d := range deployments.Items {
-		log.Info().Str("status", d.Status.String()).Msg("Deployment info")
+		log.Debug().Str("status", d.Status.String()).Msg("Deployment info")
 		waitCmd := fmt.Sprintf("kubectl rollout status -n %s deployment/%s", namespace, d.Name)
 		log.Debug().Str("cmd", waitCmd).Msg("wait for deployment to be available")
-		if err := ExecCmd(waitCmd); err != nil {
+		if err := ExecCmdWithContext(ctx, waitCmd); err != nil {
 			return err
 		}
 	}
@@ -424,7 +424,7 @@ func (m *K8sClient) WaitForDeploymentsAvailable(namespace string) error {
 }
 
 // Apply applying a manifest to a currently connected k8s context
-func (m *K8sClient) Apply(manifest, namespace string) error {
+func (m *K8sClient) Apply(manifest, namespace string, ctx context.Context) error {
 	manifestFile := fmt.Sprintf(TempDebugManifest, uuid.NewString())
 	log.Info().Str("File", manifestFile).Msg("Applying manifest")
 	if err := os.WriteFile(manifestFile, []byte(manifest), os.ModePerm); err != nil {
@@ -432,10 +432,10 @@ func (m *K8sClient) Apply(manifest, namespace string) error {
 	}
 	cmd := fmt.Sprintf("kubectl apply -f %s", manifestFile)
 	log.Debug().Str("cmd", cmd).Msg("Apply command")
-	if err := ExecCmd(cmd); err != nil {
+	if err := ExecCmdWithContext(ctx, cmd); err != nil {
 		return err
 	}
-	return m.WaitForDeploymentsAvailable(namespace)
+	return m.WaitForDeploymentsAvailable(namespace, ctx)
 }
 
 // DeleteResource deletes resource

--- a/client/cmd.go
+++ b/client/cmd.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"os/exec"
 	"strings"
@@ -10,7 +11,11 @@ import (
 )
 
 func ExecCmd(command string) error {
-	return ExecCmdWithOptions(command, func(m string) {
+	return ExecCmdWithContext(context.Background(), command)
+}
+
+func ExecCmdWithContext(ctx context.Context, command string) error {
+	return ExecCmdWithOptions(ctx, command, func(m string) {
 		log.Debug().Str("Text", m).Msg("Std Pipe")
 	})
 }
@@ -27,9 +32,9 @@ func readStdPipe(pipe io.ReadCloser, outputFunction func(string)) {
 	}
 }
 
-func ExecCmdWithOptions(command string, outputFunction func(string)) error {
+func ExecCmdWithOptions(ctx context.Context, command string, outputFunction func(string)) error {
 	c := strings.Split(command, " ")
-	cmd := exec.Command(c[0], c[1:]...)
+	cmd := exec.CommandContext(ctx, c[0], c[1:]...)
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		return err

--- a/e2e/common/test_common.go
+++ b/e2e/common/test_common.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/onsi/gomega"
@@ -342,10 +343,10 @@ func TestRolloutRestart(t *testing.T, statefulSet bool) {
 	})
 
 	if statefulSet {
-		err = e.Client.RolloutStatefulSets(e.Cfg.Namespace)
+		err = e.RolloutStatefulSets()
 		require.NoError(t, err, "failed to rollout statefulsets")
 	} else {
-		err = e.Client.RolloutRestartBySelector(e.Cfg.Namespace, "deployment", "envType=chainlink-env-test")
+		err = e.RolloutRestartBySelector("deployment", "envType=chainlink-env-test")
 		require.NoError(t, err, "failed to rollout restart deployment")
 	}
 
@@ -397,4 +398,13 @@ func TestReplaceHelm(t *testing.T) {
 	require.NoError(t, err)
 	err = e.Run()
 	require.NoError(t, err)
+}
+
+func TestRunTimeout(t *testing.T) {
+	t.Parallel()
+	testEnvConfig := GetTestEnvConfig(t)
+	e := presets.EVMOneNode(testEnvConfig)
+	e.Cfg.ReadyCheckData.Timeout = 5 * time.Second
+	err := e.Run()
+	require.Error(t, err)
 }

--- a/e2e/local-runner/envs_test.go
+++ b/e2e/local-runner/envs_test.go
@@ -57,3 +57,7 @@ func TestRolloutRestartBySelector(t *testing.T) {
 func TestReplaceHelm(t *testing.T) {
 	common.TestReplaceHelm(t)
 }
+
+func TestRunTimeout(t *testing.T) {
+	common.TestRunTimeout(t)
+}

--- a/e2e/remote-runner/remote_runner_envs_test.go
+++ b/e2e/remote-runner/remote_runner_envs_test.go
@@ -147,3 +147,7 @@ func TestRolloutRestartBySelector(t *testing.T) {
 func TestReplaceHelm(t *testing.T) {
 	common.TestReplaceHelm(t)
 }
+
+func TestRunTimeout(t *testing.T) {
+	common.TestRunTimeout(t)
+}

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -299,7 +299,7 @@ func (m *Environment) initApp() error {
 	m.CurrentManifest = *m.App.SynthYaml()
 	ctx, cancel := context.WithTimeout(context.Background(), m.Cfg.ReadyCheckData.Timeout)
 	defer cancel()
-	err = m.Client.Apply(m.CurrentManifest, m.Cfg.Namespace, ctx)
+	err = m.Client.Apply(ctx, m.CurrentManifest, m.Cfg.Namespace)
 	if ctx.Err() == context.DeadlineExceeded {
 		return fmt.Errorf("failed to apply manifest within %s", m.Cfg.ReadyCheckData.Timeout)
 	}
@@ -700,7 +700,7 @@ func (m *Environment) DeployCustomReadyConditions(customCheck *client.ReadyCheck
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), m.Cfg.ReadyCheckData.Timeout)
 	defer cancel()
-	err := m.Client.Apply(m.CurrentManifest, m.Cfg.Namespace, ctx)
+	err := m.Client.Apply(ctx, m.CurrentManifest, m.Cfg.Namespace)
 	if ctx.Err() == context.DeadlineExceeded {
 		return errors.New("timeout waiting for environment to be ready")
 	}
@@ -751,7 +751,7 @@ func (m *Environment) RolloutStatefulSets() error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), m.Cfg.ReadyCheckData.Timeout)
 	defer cancel()
-	err := m.Client.RolloutStatefulSets(m.Cfg.Namespace, ctx)
+	err := m.Client.RolloutStatefulSets(ctx, m.Cfg.Namespace)
 	if ctx.Err() == context.DeadlineExceeded {
 		return errors.New("timeout waiting for rollout statefulset to complete")
 	}
@@ -765,7 +765,7 @@ func (m *Environment) RolloutRestartBySelector(resource string, selector string)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), m.Cfg.ReadyCheckData.Timeout)
 	defer cancel()
-	err := m.Client.RolloutRestartBySelector(m.Cfg.Namespace, resource, selector, ctx)
+	err := m.Client.RolloutRestartBySelector(ctx, m.Cfg.Namespace, resource, selector)
 	if ctx.Err() == context.DeadlineExceeded {
 		return errors.New("timeout waiting for rollout restart to complete")
 	}


### PR DESCRIPTION
Prevents infinite waits on the kubectl status calls that have no way of specifying a timeout otherwise.