### PR TITLE
[TT-597] Add environment.Config variable to dynamically add pod eviction as needed instead of default

### DIFF
--- a/environment/environment.go
+++ b/environment/environment.go
@@ -78,6 +78,8 @@ type Config struct {
 	// PodLabels is a set of labels applied to every pod in the namespace
 	PodLabels map[string]string
 	// PreventPodEviction if true sets a k8s annotation safe-to-evict=false to prevent pods from being evicted
+	// Note: This should only be used if your test is completely incapable of handling things like K8s rebalances without failing.
+	// If that is the case, it's worth the effort to make your test fault-tolerant soon. The alternative is expensive and infuriating.
 	PreventPodEviction bool
 	// Allow deployment to nodes with these tolerances
 	Tolerations []map[string]string

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -387,7 +387,7 @@ func (m *Environment) ReplaceHelm(name string, chart ConnectedChart) (*Environme
 		ReleaseName: a.Str(name),
 		Values:      chart.GetValues(),
 	})
-	addDefaultPodAnnotationsAndLabels(h, addSafeToEvictPrevention(m.Cfg.PreventPodEviction, nil), m.Cfg.PodLabels)
+	addDefaultPodAnnotationsAndLabels(h, markNotSafeToEvict(m.Cfg.PreventPodEviction, nil), m.Cfg.PodLabels)
 	m.Charts = append(m.Charts, chart)
 	return m, nil
 }
@@ -518,7 +518,7 @@ func (m *Environment) AddHelm(chart ConnectedChart) *Environment {
 		ReleaseName: a.Str(chart.GetName()),
 		Values:      values,
 	})
-	addDefaultPodAnnotationsAndLabels(h, addSafeToEvictPrevention(m.Cfg.PreventPodEviction, nil), m.Cfg.PodLabels)
+	addDefaultPodAnnotationsAndLabels(h, markNotSafeToEvict(m.Cfg.PreventPodEviction, nil), m.Cfg.PodLabels)
 	m.Charts = append(m.Charts, chart)
 	return m
 }
@@ -1023,8 +1023,8 @@ func DefaultJobLogFunction(e *Environment, message string) {
 	}
 }
 
-// addSafeToEvictPrevention adds the safe to evict annotation to the provided map if needed
-func addSafeToEvictPrevention(preventPodEviction bool, m map[string]string) map[string]string {
+// markNotSafeToEvict adds the safe to evict annotation to the provided map if needed
+func markNotSafeToEvict(preventPodEviction bool, m map[string]string) map[string]string {
 	if m == nil {
 		m = make(map[string]string)
 	}

--- a/environment/runner.go
+++ b/environment/runner.go
@@ -122,7 +122,7 @@ func role(chart cdk8s.Chart, props *Props) {
 }
 
 func job(chart cdk8s.Chart, props *Props) {
-	defaultRunnerPodAnnotations := addSafeToEvictPrevention(props.PreventPodEviction, nil)
+	defaultRunnerPodAnnotations := markNotSafeToEvict(props.PreventPodEviction, nil)
 	restartPolicy := "Never"
 	backOffLimit := float64(0)
 	if os.Getenv(config.EnvVarDetachRunner) == "true" { // If we're running detached, we're likely running a long-form test


### PR DESCRIPTION
It can now be enabled with environment.Config.PreventPodEviction=true
This will help us keep from locking up the k8s cluster for jobs that do not require pod eviction prevention.